### PR TITLE
Fix contract compatibility with PHP 8

### DIFF
--- a/src/common/mixins/StrictBehaviorMixin.php
+++ b/src/common/mixins/StrictBehaviorMixin.php
@@ -65,7 +65,7 @@ trait StrictBehaviorMixin
      * @param string $name
      * @throws UndefinedPropertyException
      */
-    public function __isset(string $name): void
+    public function __isset(string $name): bool
     {
         throw new UndefinedPropertyException(static::class, $name);
     }


### PR DESCRIPTION
It's parse error in PHP 8 (Return type must be bool when declared)