### PR TITLE
Allow newer Nette dependencies due to PHP 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-calendar":"*",
-        "nette/http": "~2.4|~3.0",
-        "nette/utils": "~2.4|~3.0"
+        "nette/http": "^2.4|^3.0|~4.0",
+        "nette/utils": "^2.4|^3.0|~4.0"
     },
     "require-dev": {
         "dogma/dogma-dev": "0.1.29",


### PR DESCRIPTION
nette/http `~3.0` (`>=3.0 <3.1`) has `php: >=7.1 <8.1` requirement which blocks upgrade of PHP.
Checks with the newest versions passed except spell and phpcs on PHP 8.2 (Some Slevomat standards are automatically enabled based on PHP version).