### PR TITLE
composer: dump `tests/*` autoloading only in dev-mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
         }
     },
     "autoload": {
-        "classmap": ["src", "tests"]
+        "classmap": ["src"]
+    },
+    "autoload-dev": {
+        "classmap": ["tests"]
     },
     "scripts": {
         "da": "composer dump-autoload",


### PR DESCRIPTION
autoloading of tests should not be mixed into the consuming projects prod autoload map