### PR TITLE
NightInterval::containsValue() fix

### DIFF
--- a/src/Time/Interval/NightInterval.php
+++ b/src/Time/Interval/NightInterval.php
@@ -311,6 +311,10 @@ class NightInterval implements Interval, DateOrTimeInterval, Pokeable
      */
     public function containsValue($date): bool
     {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
         if (!$date instanceof Date) {
             $date = Date::createFromDateTimeInterface($date);
         }

--- a/tests/src/Time/Interval/NightInterval.phpt
+++ b/tests/src/Time/Interval/NightInterval.phpt
@@ -150,6 +150,7 @@ Assert::false($interval->containsValue($d(21)));
 Assert::false($interval->containsValue($d(5)));
 Assert::false($interval->containsValue($d(25)));
 Assert::true($interval->containsValue(new DateTimeImmutable('2000-01-15')));
+Assert::false($empty->containsValue($d(10)));
 
 
 contains:


### PR DESCRIPTION
Bez tohoto fixu spadne empty interval na  `$this->end->subtractDay()`
konkrétně:
_Dogma\ValueOutOfRangeException
Expected a value within the range of 1721426 and 5373484. Value 1721425 given._