### PR TITLE
Formatted empty interval should parse back to empty interval

### DIFF
--- a/src/Time/Interval/DateTimeInterval.php
+++ b/src/Time/Interval/DateTimeInterval.php
@@ -81,6 +81,9 @@ class DateTimeInterval implements Interval, DateOrTimeInterval
 
         $start = new DateTime($start);
         $end = new DateTime($end);
+        if ($start > $end) {
+            return self::empty();
+        }
 
         return new static($start, $end);
     }

--- a/src/Time/Interval/NightInterval.php
+++ b/src/Time/Interval/NightInterval.php
@@ -101,17 +101,11 @@ class NightInterval implements Interval, DateOrTimeInterval, Pokeable
         if ($openEnd) {
             $end = $end->subtractDay();
         }
-
-        $startJd = $start->getJulianDay();
-        $endJd = $end->getJulianDay();
-
-        if ($startJd > $endJd) {
-            throw new InvalidIntervalStartEndOrderException($start, $end);
-        } elseif ($startJd === $endJd) {
+        if ($start->getJulianDay() >= $end->getJulianDay()) {
             return self::empty();
-        } else {
-            return new static($start, $end);
         }
+
+        return new static($start, $end);
     }
 
     public static function createFromStartAndLength(Date $start, DateTimeUnit $unit, int $amount): self

--- a/tests/src/Time/Interval/DateInterval.phpt
+++ b/tests/src/Time/Interval/DateInterval.phpt
@@ -49,6 +49,7 @@ Assert::equal(DateInterval::createFromString('[2000-01-10,2000-01-20]'), $interv
 Assert::equal(DateInterval::createFromString('[2000-01-10,2000-01-21)'), $interval);
 Assert::equal(DateInterval::createFromString('(2000-01-09,2000-01-21)'), $interval);
 Assert::equal(DateInterval::createFromString('(2000-01-09,2000-01-20]'), $interval);
+Assert::equal(DateInterval::createFromString($empty->format()), $empty);
 Assert::exception(static function (): void {
     DateInterval::createFromString('foo|bar|baz');
 }, InvalidIntervalStringFormatException::class);

--- a/tests/src/Time/Interval/DateTimeInterval.phpt
+++ b/tests/src/Time/Interval/DateTimeInterval.phpt
@@ -52,6 +52,7 @@ Assert::equal(DateTimeInterval::createFromString('2000-01-10 00:00,2000-01-20 00
 Assert::equal(DateTimeInterval::createFromString('2000-01-10 00:00|2000-01-20 00:00'), $interval);
 Assert::equal(DateTimeInterval::createFromString('2000-01-10 00:00/2000-01-20 00:00'), $interval);
 Assert::equal(DateTimeInterval::createFromString('2000-01-10 00:00 - 2000-01-20 00:00'), $interval);
+Assert::equal(DateTimeInterval::createFromString($empty->format()), $empty);
 Assert::exception(static function (): void {
     DateTimeInterval::createFromString('foo|bar|baz');
 }, InvalidIntervalStringFormatException::class);

--- a/tests/src/Time/Interval/NightInterval.phpt
+++ b/tests/src/Time/Interval/NightInterval.phpt
@@ -55,6 +55,7 @@ Assert::equal(NightInterval::createFromString('[2000-01-10,2000-01-21]'), $inter
 Assert::equal(NightInterval::createFromString('[2000-01-10,2000-01-22)'), $interval);
 Assert::equal(NightInterval::createFromString('(2000-01-09,2000-01-22)'), $interval);
 Assert::equal(NightInterval::createFromString('(2000-01-09,2000-01-21]'), $interval);
+Assert::equal(NightInterval::createFromString($empty->format()), $empty);
 Assert::exception(static function (): void {
     NightInterval::createFromString('foo|bar|baz');
 }, InvalidIntervalStringFormatException::class);

--- a/tests/src/Time/Interval/TimeInterval.phpt
+++ b/tests/src/Time/Interval/TimeInterval.phpt
@@ -47,6 +47,7 @@ Assert::equal(TimeInterval::createFromString('00:00 - 00:00'), new TimeInterval(
 Assert::equal(TimeInterval::createFromString('00:00 - 00:00')->getLengthInMicroseconds(), 0);
 Assert::equal(TimeInterval::createFromString('00:00 - 24:00'), new TimeInterval($t(0), $t(24)));
 Assert::equal(TimeInterval::createFromString('00:00 - 24:00')->getLengthInMicroseconds(), Microseconds::DAY);
+Assert::equal(TimeInterval::createFromString($empty->format()), $empty);
 Assert::exception(static function (): void {
     TimeInterval::createFromString('foo|bar|baz');
 }, InvalidIntervalStringFormatException::class);


### PR DESCRIPTION
Opraveno po vzoru `DateInterval::createFromString` která již empty interval umí vyrobit.

- `DayOfYearInterval ` s tím nevím jak si poradit, volání fce `format` na empty intervalu vyhodí chybu, ale nelze to formátovat jako `12-31 - 01-01`, protože to je validní neprázdný interval.

- `TimeInterval` funguje bez zásahu (empty je reprezentován jinak než `<MAX, MIN>`).

Fixes #24 
